### PR TITLE
p5.playのSpriteを使用した足場の実装と視覚表現の改善

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -34,6 +34,9 @@ export const COLOR_PALETTE = {
     PLAYER_OUTLINE: '#8B2500', // プレイヤーの輪郭/シャドウ
     PLAYER_HIGHLIGHT: '#FFAB91', // プレイヤーのハイライト
     PLATFORM: '#4CAF50', // 緑色の足場
+    PLATFORM_GRASS: '#8BC34A', // 足場の上の草
+    PLATFORM_STONE: '#607D8B', // 石の足場
+    PLATFORM_STONE_DETAIL: '#455A64', // 石の模様
     TEXT: '#333333', // 黒に近いテキスト
     UI_BACKGROUND: 'rgba(255, 255, 255, 0.7)', // 半透明の白色UI背景
 };

--- a/js/platform.js
+++ b/js/platform.js
@@ -5,6 +5,14 @@ import { PLATFORM_HEIGHT, PLATFORM_SPEED, COLOR_PALETTE } from './config.js';
 
 // p5.js関数は window.p5Globals 経由で直接アクセス
 
+// プラットフォームの種類と表現に関する定数
+const PLATFORM_TYPE_COUNT = 3; // プラットフォームのタイプ数
+const PLATFORM_TYPE_BASIC = 0;
+const PLATFORM_TYPE_GRASSY = 1;
+const PLATFORM_TYPE_STONE = 2;
+const GRASS_PIXEL_SIZE = 3; // 草のピクセルサイズ
+const STONE_DETAIL_SIZE = 4; // 石のディテールサイズ
+
 export class Platform {
     /**
      * プラットフォームを初期化する
@@ -19,7 +27,7 @@ export class Platform {
         this.height = PLATFORM_HEIGHT;
         this.speed = PLATFORM_SPEED;
         this.sprite = null;
-        this.type = Math.floor(window.random(3)); // 0, 1, 2の3種類のタイプをランダムに選択
+        this.type = Math.floor(window.random(PLATFORM_TYPE_COUNT)); // ランダムなプラットフォームタイプを選択
     }
 
     /** 初期化処理（必要に応じて） */
@@ -31,7 +39,7 @@ export class Platform {
         );
         this.sprite.width = this.width;
         this.sprite.height = this.height;
-        this.sprite.collider = 'static'; // 静的なコライダー（動かない物体）
+        this.sprite.immovable = true; // 静的なスプライト（動かない物体）
         this.sprite.visible = false; // カスタム描画を使用するため、デフォルトのスプライト表示を無効化
     }
 
@@ -48,17 +56,15 @@ export class Platform {
 
     /** プラットフォームを描画 */
     draw() {
-        window.push();
-
-        // タイプに応じて描画を変える
+        window.push(); // タイプに応じて描画を変える
         switch (this.type) {
-            case 0: // 基本的な足場
+            case PLATFORM_TYPE_BASIC: // 基本的な足場
                 this.drawBasicPlatform();
                 break;
-            case 1: // ドット絵風の草地
+            case PLATFORM_TYPE_GRASSY: // ドット絵風の草地
                 this.drawGrassyPlatform();
                 break;
-            case 2: // 石のような足場
+            case PLATFORM_TYPE_STONE: // 石のような足場
                 this.drawStonePlatform();
                 break;
         }
@@ -99,10 +105,8 @@ export class Platform {
 
         // 草の部分（上部の装飾）
         window.fill(COLOR_PALETTE.PLATFORM_GRASS);
-        const grassHeight = 5;
-
-        // 草のピクセル表現
-        const pixelSize = 3;
+        const grassHeight = 5; // 草のピクセル表現
+        const pixelSize = GRASS_PIXEL_SIZE;
         const numGrass = Math.floor(this.width / pixelSize);
 
         for (let i = 0; i < numGrass; i++) {
@@ -131,11 +135,9 @@ export class Platform {
             this.y + this.height / 2,
             this.width,
             this.height
-        );
-
-        // 石のテクスチャ表現
+        ); // 石のテクスチャ表現
         window.fill(COLOR_PALETTE.PLATFORM_STONE_DETAIL);
-        const detailSize = 4;
+        const detailSize = STONE_DETAIL_SIZE;
         const numDetails = Math.floor(
             ((this.width * this.height) / (detailSize * detailSize)) * 0.1
         ); // 10%程度の密度

--- a/js/platform.js
+++ b/js/platform.js
@@ -18,26 +18,156 @@ export class Platform {
         this.width = width;
         this.height = PLATFORM_HEIGHT;
         this.speed = PLATFORM_SPEED;
+        this.sprite = null;
+        this.type = Math.floor(window.random(3)); // 0, 1, 2の3種類のタイプをランダムに選択
     }
 
     /** 初期化処理（必要に応じて） */
     setup() {
-        // 現在は追加処理なし
+        // Spriteを作成
+        this.sprite = new window.Sprite(
+            this.x + this.width / 2,
+            this.y + this.height / 2
+        );
+        this.sprite.width = this.width;
+        this.sprite.height = this.height;
+        this.sprite.collider = 'static'; // 静的なコライダー（動かない物体）
+        this.sprite.visible = false; // カスタム描画を使用するため、デフォルトのスプライト表示を無効化
     }
 
     /** プラットフォームの移動を更新 */
     update() {
         this.x -= this.speed;
+
+        // スプライトの位置も更新
+        if (this.sprite) {
+            this.sprite.x = this.x + this.width / 2;
+            this.sprite.y = this.y + this.height / 2;
+        }
     }
 
     /** プラットフォームを描画 */
     draw() {
-        window.fill(COLOR_PALETTE.PLATFORM);
-        window.rect(this.x, this.y, this.width, this.height);
+        window.push();
+
+        // タイプに応じて描画を変える
+        switch (this.type) {
+            case 0: // 基本的な足場
+                this.drawBasicPlatform();
+                break;
+            case 1: // ドット絵風の草地
+                this.drawGrassyPlatform();
+                break;
+            case 2: // 石のような足場
+                this.drawStonePlatform();
+                break;
+        }
+
+        // デバッグ用：衝突範囲の表示（必要に応じてコメントアウト）
+        // window.noFill();
+        // window.stroke('#ff0000');
+        // window.rect(this.x + this.width/2, this.y + this.height/2, this.width, this.height);
+
+        window.pop();
     }
 
-    /** 画面外判定 */
+    /**
+     * 基本的な足場を描画
+     */
+    drawBasicPlatform() {
+        window.fill(COLOR_PALETTE.PLATFORM);
+        window.rect(
+            this.x + this.width / 2,
+            this.y + this.height / 2,
+            this.width,
+            this.height
+        );
+    }
+
+    /**
+     * 草地風の足場を描画
+     */
+    drawGrassyPlatform() {
+        // 足場のベース部分
+        window.fill(COLOR_PALETTE.PLATFORM);
+        window.rect(
+            this.x + this.width / 2,
+            this.y + this.height / 2,
+            this.width,
+            this.height
+        );
+
+        // 草の部分（上部の装飾）
+        window.fill(COLOR_PALETTE.PLATFORM_GRASS);
+        const grassHeight = 5;
+
+        // 草のピクセル表現
+        const pixelSize = 3;
+        const numGrass = Math.floor(this.width / pixelSize);
+
+        for (let i = 0; i < numGrass; i++) {
+            if (window.random() > 0.6) {
+                // 一部の場所だけ草を生やす
+                let grassX = this.x + i * pixelSize;
+                if (grassX < this.x + this.width) {
+                    window.rect(
+                        grassX,
+                        this.y - grassHeight / 2,
+                        pixelSize,
+                        grassHeight
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * 石のような足場を描画
+     */
+    drawStonePlatform() {
+        window.fill(COLOR_PALETTE.PLATFORM_STONE);
+        window.rect(
+            this.x + this.width / 2,
+            this.y + this.height / 2,
+            this.width,
+            this.height
+        );
+
+        // 石のテクスチャ表現
+        window.fill(COLOR_PALETTE.PLATFORM_STONE_DETAIL);
+        const detailSize = 4;
+        const numDetails = Math.floor(
+            ((this.width * this.height) / (detailSize * detailSize)) * 0.1
+        ); // 10%程度の密度
+
+        for (let i = 0; i < numDetails; i++) {
+            const detailX = this.x + window.random(this.width);
+            const detailY = this.y + window.random(this.height);
+            window.rect(detailX, detailY, detailSize, detailSize);
+        }
+    }
+
+    /**
+     * 画面外判定
+     * @returns {boolean} 足場が画面外に出た場合はtrue
+     */
     isOffScreen() {
-        return this.x + this.width < 0;
+        // 足場全体が画面外に出たらtrue
+        const result = this.x + this.width < 0;
+
+        // 画面外に出たらスプライトも削除
+        if (result && this.sprite) {
+            this.sprite.remove();
+        }
+
+        return result;
+    }
+
+    /**
+     * display()メソッド（draw()と同一機能）
+     * issue命名規則に合わせて追加
+     */
+    display() {
+        this.draw();
     }
 }

--- a/js/player.js
+++ b/js/player.js
@@ -207,7 +207,7 @@ export class Player {
                     // プレイヤーの下半分と足場の上部との衝突判定                    // 自分の下端と足場の上端の位置関係
                     const playerBottom = this.y + PLAYER_SIZE / 2;
                     const platformTop = platform.y;
-                    
+
                     // 横方向の衝突範囲
                     const playerLeft = this.x - PLAYER_SIZE / 2;
                     const playerRight = this.x + PLAYER_SIZE / 2;

--- a/js/player.js
+++ b/js/player.js
@@ -204,7 +204,8 @@ export class Player {
             for (let platform of platforms) {
                 if (platform.sprite && this.sprite) {
                     // p5.playのスプライト衝突判定を活用
-                    // プレイヤーの下半分と足場の上部との衝突判定                    // 自分の下端と足場の上端の位置関係
+                    // プレイヤーの下半分と足場の上部との衝突判定
+                    // 自分の下端と足場の上端の位置関係
                     const playerBottom = this.y + PLAYER_SIZE / 2;
                     const platformTop = platform.y;
 

--- a/js/player.js
+++ b/js/player.js
@@ -199,32 +199,60 @@ export class Player {
     checkCollision(platforms) {
         if (!platforms) return;
 
-        for (let platform of platforms) {
-            // 自分の下端と足場の上端の位置関係
-            const playerBottom = this.y + PLAYER_SIZE / 2;
-            const platformTop = platform.y;
+        // 落下中（速度が正）かつまだ着地していない場合のみ衝突判定を行う
+        if (this.velocity > 0 && !this.grounded) {
+            for (let platform of platforms) {
+                if (platform.sprite && this.sprite) {
+                    // p5.playのスプライト衝突判定を活用
+                    // プレイヤーの下半分と足場の上部との衝突判定
 
-            // 横方向の衝突範囲
-            const playerLeft = this.x - PLAYER_SIZE / 2;
-            const playerRight = this.x + PLAYER_SIZE / 2;
-            const platformLeft = platform.x;
-            const platformRight = platform.x + platform.width;
+                    // 自分の下端と足場の上端の位置関係
+                    const playerBottom = this.y + PLAYER_SIZE / 2;
+                    const platformTop = platform.y;
 
-            // 足場の上に着地する場合の判定
-            // 1. 足場の上で、かつ
-            // 2. 横方向で足場の範囲内、かつ
-            // 3. 落下中（速度が正）
-            if (
-                playerBottom >= platformTop &&
-                playerBottom <= platformTop + platform.height / 2 &&
-                playerRight >= platformLeft &&
-                playerLeft <= platformRight &&
-                this.velocity > 0
-            ) {
-                // 足場の上に位置を補正
-                this.y = platformTop - PLAYER_SIZE / 2;
-                this.velocity = 0;
-                this.grounded = true;
+                    // 足場の上に着地する場合の判定
+                    // 1. プレイヤーの下部が足場より下にある
+                    // 2. プレイヤーの前回の位置が足場より上にあった（落下中に足場と衝突）
+                    if (
+                        playerBottom >= platformTop &&
+                        playerBottom <= platformTop + platform.height / 2 &&
+                        this.y - this.velocity < platformTop - PLAYER_SIZE / 2
+                    ) {
+                        if (this.sprite.collides(platform.sprite)) {
+                            // 足場の上に位置を補正
+                            this.y = platformTop - PLAYER_SIZE / 2;
+                            this.velocity = 0;
+                            this.grounded = true;
+                            break; // 一度着地したら他の足場の判定は不要
+                        }
+                    }
+                } else {
+                    // スプライトが存在しない場合はフォールバック処理（既存の処理）
+                    // 自分の下端と足場の上端の位置関係
+                    const playerBottom = this.y + PLAYER_SIZE / 2;
+                    const platformTop = platform.y;
+
+                    // 横方向の衝突範囲
+                    const playerLeft = this.x - PLAYER_SIZE / 2;
+                    const playerRight = this.x + PLAYER_SIZE / 2;
+                    const platformLeft = platform.x;
+                    const platformRight = platform.x + platform.width;
+
+                    // 足場の上に着地する場合の判定
+                    if (
+                        playerBottom >= platformTop &&
+                        playerBottom <= platformTop + platform.height / 2 &&
+                        playerRight >= platformLeft &&
+                        playerLeft <= platformRight &&
+                        this.velocity > 0
+                    ) {
+                        // 足場の上に位置を補正
+                        this.y = platformTop - PLAYER_SIZE / 2;
+                        this.velocity = 0;
+                        this.grounded = true;
+                        break; // 一度着地したら他の足場の判定は不要
+                    }
+                }
             }
         }
     }

--- a/js/player.js
+++ b/js/player.js
@@ -204,18 +204,25 @@ export class Player {
             for (let platform of platforms) {
                 if (platform.sprite && this.sprite) {
                     // p5.playのスプライト衝突判定を活用
-                    // プレイヤーの下半分と足場の上部との衝突判定
-
-                    // 自分の下端と足場の上端の位置関係
+                    // プレイヤーの下半分と足場の上部との衝突判定                    // 自分の下端と足場の上端の位置関係
                     const playerBottom = this.y + PLAYER_SIZE / 2;
                     const platformTop = platform.y;
+                    
+                    // 横方向の衝突範囲
+                    const playerLeft = this.x - PLAYER_SIZE / 2;
+                    const playerRight = this.x + PLAYER_SIZE / 2;
+                    const platformLeft = platform.x;
+                    const platformRight = platform.x + platform.width;
 
                     // 足場の上に着地する場合の判定
                     // 1. プレイヤーの下部が足場より下にある
-                    // 2. プレイヤーの前回の位置が足場より上にあった（落下中に足場と衝突）
+                    // 2. 横方向で足場の範囲内
+                    // 3. プレイヤーの前回の位置が足場より上にあった（落下中に足場と衝突）
                     if (
                         playerBottom >= platformTop &&
                         playerBottom <= platformTop + platform.height / 2 &&
+                        playerRight >= platformLeft &&
+                        playerLeft <= platformRight &&
                         this.y - this.velocity < platformTop - PLAYER_SIZE / 2
                     ) {
                         if (this.sprite.collides(platform.sprite)) {

--- a/js/stage_generator.js
+++ b/js/stage_generator.js
@@ -26,13 +26,14 @@ export class StageGenerator {
 
     /**
      * プラットフォームの生成と更新を行う
-     */
-    update() {
+     */ update() {
         // 一定間隔でプラットフォームを生成
         if (window.frameCount % PLATFORM_SPAWN_INTERVAL === 0) {
             const w = window.random(PLATFORM_MIN_WIDTH, PLATFORM_MAX_WIDTH);
             const y = window.random(PLATFORM_MIN_HEIGHT, PLATFORM_MAX_HEIGHT);
-            this.platforms.push(new Platform(window.width, y, w));
+            const platform = new Platform(window.width, y, w);
+            platform.setup(); // スプライトを初期化
+            this.platforms.push(platform);
         }
         // 各プラットフォームの更新
         this.platforms.forEach((p) => p.update());

--- a/js/stage_generator.js
+++ b/js/stage_generator.js
@@ -22,11 +22,10 @@ export class StageGenerator {
      */
     setup() {
         this.platforms = [];
-    }
-
-    /**
+    }    /**
      * プラットフォームの生成と更新を行う
-     */ update() {
+     */
+    update() {
         // 一定間隔でプラットフォームを生成
         if (window.frameCount % PLATFORM_SPAWN_INTERVAL === 0) {
             const w = window.random(PLATFORM_MIN_WIDTH, PLATFORM_MAX_WIDTH);

--- a/js/stage_generator.js
+++ b/js/stage_generator.js
@@ -22,7 +22,8 @@ export class StageGenerator {
      */
     setup() {
         this.platforms = [];
-    }    /**
+    }
+    /**
      * プラットフォームの生成と更新を行う
      */
     update() {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
## 概要
Issue #5「足場（プラットフォーム）の実装」の未完了だった項目を実装しました。

## 変更内容
1. `platform.js`の改良
   - p5.playのSpriteを使用した足場の表現
   - 3種類の足場バリエーション（基本、草地風、石のような足場）の実装
   - ドット絵風の視覚表現を追加

2. `config.js`の修正
   - 新しい足場のバリエーション用の色設定を追加

3. `stage_generator.js`の修正
   - プラットフォーム生成時に`setup()`メソッドを呼び出すよう変更

4. `player.js`の修正
   - 衝突判定にp5.playのスプライト機能を活用

## 確認事項
- [x] 足場が一定のスピードで左にスクロールすること
- [x] プレイヤーキャラクターが足場の上に立てること（衝突判定が機能すること）
- [x] 足場がドット絵風もしくはシンプルな図形で表現されていること
- [x] 画面外に出た足場が正しく判定されること
- [x] p5.playのスプライト機能が正しく活用されていること
<!-- I want to review in Japanese. -->